### PR TITLE
Refactor/run service

### DIFF
--- a/src/wes_service/api/routes/runs.py
+++ b/src/wes_service/api/routes/runs.py
@@ -101,8 +101,7 @@ async def run_workflow(
     The workflow_params JSON object specifies input parameters.
     The exact format depends on the workflow language conventions.
     """
-    workflow_submission = LambdaWorkflowSubmissionService()
-    service = RunService(db, storage, workflow_submission)
+    service = RunService(db, storage)
     response = await service.create_run(
         workflow_params=workflow_params,
         workflow_type=workflow_type,

--- a/src/wes_service/api/routes/runs.py
+++ b/src/wes_service/api/routes/runs.py
@@ -102,24 +102,36 @@ async def run_workflow(
     The exact format depends on the workflow language conventions.
     """
     service = RunService(db, storage)
-    response = await service.create_run(
-        workflow_params=workflow_params,
-        workflow_type=workflow_type,
-        workflow_type_version=workflow_type_version,
-        workflow_url=workflow_url,
-        workflow_attachments=workflow_attachment,
-        tags=tags,
-        workflow_engine=workflow_engine,
-        workflow_engine_version=workflow_engine_version,
-        workflow_engine_parameters=workflow_engine_parameters,
-        user_id=user,
-    )
-    if "error" in response:
+    try:
+        run = await service.create_run(
+            workflow_params=workflow_params,
+            workflow_type=workflow_type,
+            workflow_type_version=workflow_type_version,
+            workflow_url=workflow_url,
+            workflow_attachments=workflow_attachment,
+            tags=tags,
+            workflow_engine=workflow_engine,
+            workflow_engine_version=workflow_engine_version,
+            workflow_engine_parameters=workflow_engine_parameters,
+            user_id=user,
+        )
+    except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=response["error"],
+            detail=str(e),
         )
-    return RunId(run_id=response["run_id"])
+
+    # Ping LambdaWorkflowSubmissionService to trigger processing of the new run
+    try:
+        submission_service = LambdaWorkflowSubmissionService()
+        await submission_service.submit_workflow(run, db)
+    except Exception as e:
+        logger.exception(
+            "Failed to trigger run processing request for run_id %s: %s",
+            run.id,
+            e
+        )
+    return RunId(run_id=run.id)
 
 
 @router.get(

--- a/src/wes_service/services/run_service.py
+++ b/src/wes_service/services/run_service.py
@@ -37,12 +37,10 @@ class RunService:
         self,
         db: AsyncSession,
         storage: StorageBackend,
-        workflow_submission: WorkflowSubmissionService = None
     ):
         """Initialize run service."""
         self.db = db
         self.storage = storage
-        self.workflow_submission = workflow_submission
         self.settings = get_settings()
 
     async def create_run(
@@ -152,43 +150,43 @@ class RunService:
         await self.db.commit()
 
         # Submit workflow for execution
-        logger.info(f"Submitting workflow {run_id} for execution")
-        submission_response = await self.workflow_submission.submit_workflow(run, self.db)
+        # logger.info(f"Submitting workflow {run_id} for execution")
+        # submission_response = await self.workflow_submission.submit_workflow(run, self.db)
 
-        if 'omics_run_id' not in submission_response:
-            logger.error("Workflow submission response did not contain omics_run_id")
-            run.state = WorkflowState.SYSTEM_ERROR
+        # if 'omics_run_id' not in submission_response:
+        #     logger.error("Workflow submission response did not contain omics_run_id")
+        #     run.state = WorkflowState.SYSTEM_ERROR
 
-            detailed_error = None
-            if run.system_logs:
-                # Get the last error message (most recent one from workflow submission)
-                for log_entry in reversed(run.system_logs):
-                    if log_entry and not log_entry.startswith("Successfully"):
-                        detailed_error = log_entry
-                        break
+        #     detailed_error = None
+        #     if run.system_logs:
+        #         # Get the last error message (most recent one from workflow submission)
+        #         for log_entry in reversed(run.system_logs):
+        #             if log_entry and not log_entry.startswith("Successfully"):
+        #                 detailed_error = log_entry
+        #                 break
 
-            if not detailed_error:
-                detailed_error = f"Error submitting workflow {run_id} for execution"
-                run.system_logs.append(detailed_error)
+        #     if not detailed_error:
+        #         detailed_error = f"Error submitting workflow {run_id} for execution"
+        #         run.system_logs.append(detailed_error)
 
-            await self.db.commit()
-            return {"error": detailed_error}
+        #     await self.db.commit()
+        #     return {"error": detailed_error}
 
-        # Update run with execution ID but keep QUEUED state
-        if not run.outputs:
-            run.outputs = {}
+        # # Update run with execution ID but keep QUEUED state
+        # if not run.outputs:
+        #     run.outputs = {}
 
-        run.workflow_run_id = submission_response['omics_run_id']
+        # run.workflow_run_id = submission_response['omics_run_id']
 
-        # Keep state as QUEUED - EventBridge events will update status and outputs
-        run.system_logs.append(
-                f"Successfully submitted for execution. "
-                f"Omics run ID: {submission_response['omics_run_id']}")
-        await self.db.commit()
-        logger.info(
-                f"Successfully submitted workflow {run_id} for execution - "
-                "run remains QUEUED until EventBridge status update"
-        )
+        # # Keep state as QUEUED - EventBridge events will update status and outputs
+        # run.system_logs.append(
+        #         f"Successfully submitted for execution. "
+        #         f"Omics run ID: {submission_response['omics_run_id']}")
+        # await self.db.commit()
+        # logger.info(
+        #         f"Successfully submitted workflow {run_id} for execution - "
+        #         "run remains QUEUED until EventBridge status update"
+        # )
 
         return {"run_id": run_id}
 

--- a/src/wes_service/services/run_service.py
+++ b/src/wes_service/services/run_service.py
@@ -25,7 +25,6 @@ from src.wes_service.schemas.run import (
     RunStatus,
     RunSummary,
 )
-from src.wes_service.services.workflow_submission_service import WorkflowSubmissionService
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +100,8 @@ class RunService:
             self.settings.get_workflow_type_versions().keys()
         )
         if workflow_type.upper() not in supported_types:
-            error_msg = f"Unsupported workflow type: {workflow_type}. Supported types: {supported_types}"
+            error_msg = f"Unsupported workflow type: {workflow_type}. " \
+                        f"Supported types: {supported_types}"
             logger.error(error_msg)
             raise ValueError(error_msg)
 

--- a/src/wes_service/services/run_service.py
+++ b/src/wes_service/services/run_service.py
@@ -55,7 +55,7 @@ class RunService:
         workflow_engine_version: str | None,
         workflow_engine_parameters: str | None,
         user_id: str,
-    ) -> dict:
+    ) -> WorkflowRun:
         """
         Create a new workflow run.
 
@@ -72,10 +72,7 @@ class RunService:
             user_id: User creating the run
 
         Returns:
-            Dict of {
-                'run_id': str,
-                'error': str (optional)
-            }
+            WorkflowRun object representing the created workflow run
         """
         # Parse JSON strings
         params = json.loads(workflow_params) if workflow_params else {}
@@ -104,8 +101,9 @@ class RunService:
             self.settings.get_workflow_type_versions().keys()
         )
         if workflow_type.upper() not in supported_types:
-            return {"error": f"Unsupported workflow type: {workflow_type}. "
-                    f"Supported types: {supported_types}"}
+            error_msg = f"Unsupported workflow type: {workflow_type}. Supported types: {supported_types}"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
 
         # Create run record
         run_id = str(uuid4())
@@ -188,7 +186,7 @@ class RunService:
         #         "run remains QUEUED until EventBridge status update"
         # )
 
-        return {"run_id": run_id}
+        return run
 
     async def list_runs(
         self,

--- a/src/wes_service/services/workflow_submission_service.py
+++ b/src/wes_service/services/workflow_submission_service.py
@@ -1,6 +1,5 @@
 """Service layer for workflow submission operations."""
 
-import asyncio
 import boto3
 import json
 import logging
@@ -10,7 +9,6 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import attributes
 
 from src.wes_service.config import get_settings
 from src.wes_service.db.models import WorkflowRun
@@ -125,7 +123,8 @@ class LambdaWorkflowSubmissionService(WorkflowSubmissionService):
         workflow_engine_id = self._select_deployment(selected_version, suffix, workflow_id)
 
         logger.info(
-            f"Successfully retrieved workflow_engine_id '{workflow_engine_id}' for workflow {workflow_url}"
+            f"Successfully retrieved workflow_engine_id "
+            f"'{workflow_engine_id}' for workflow {workflow_url}"
         )
         return workflow_engine_id
 

--- a/src/wes_service/services/workflow_submission_service.py
+++ b/src/wes_service/services/workflow_submission_service.py
@@ -55,91 +55,57 @@ class LambdaWorkflowSubmissionService(WorkflowSubmissionService):
         settings = get_settings()
         self.ngs360_api_url = settings.ngs360_api_url
 
-    async def submit_workflow(self, run: WorkflowRun, db: AsyncSession) -> dict:
+    async def submit_workflow(self, run_request: WorkflowRun, db: AsyncSession):
         """
         Submit workflow to Lambda function for Omics execution.
 
         Args:
-            run: WorkflowRun to submit
+            run_request_id: ID of the workflow run to submit
             db: Database session for logging errors
-
-        Returns:
-            Lambda response containing omics_run_id or empty dict on failure
         """
         # Get engine_id from NGS360 API using the workflow_url as the workflow ID
         try:
-            engine_id = await self._get_engine_id_from_ngs360(run.workflow_url)
+            engine_id = await self._get_engine_id_from_ngs360(run_request.workflow_url)
         except RuntimeError as e:
             error_msg = (
                 f"Failed to retrieve engine_id from NGS360 API for workflow "
-                f"{run.workflow_url}: {str(e)}"
+                f"{run_request.workflow_url}: {str(e)}"
             )
             logger.error(error_msg)
-            run.system_logs.append(error_msg)
-            attributes.flag_modified(run, "system_logs")
-            await db.commit()
-            return {}
+            return
 
         # Prepare Lambda payload using the engine_id instead of workflow_id
         lambda_payload = {
             'action': 'submit_workflow',
             'source': 'ga4ghwes',
-            'wes_run_id': run.id,
+            'wes_run_id': run_request.id,
             'workflow_id': engine_id,  # Use engine_id from NGS360 API
             'workflow_version': (
-                run.workflow_params.get('workflow_version')
-                if run.workflow_params else None
+                run_request.workflow_params.get('workflow_version')
+                if run_request.workflow_params else None
             ),
-            'workflow_type': run.workflow_type,
-            'parameters': run.workflow_params or {},
-            'workflow_engine_parameters': run.workflow_engine_parameters or {},
+            'workflow_type': run_request.workflow_type,
+            'parameters': run_request.workflow_params or {},
+            'workflow_engine_parameters': run_request.workflow_engine_parameters or {},
             'tags': {
-                **(run.tags or {}),
-                'WESRunId': run.id
+                **(run_request.tags or {}),
+                'WESRunId': run_request.id
             }
         }
 
         logger.info(
-            f"Lambda payload for run {run.id}: "
+            f"Lambda payload for run {run_request.id}: "
             f"{json.dumps(lambda_payload, default=str)}"
         )
 
         # Call Lambda function asynchronously
-        loop = asyncio.get_event_loop()
-        response = await loop.run_in_executor(
-            None,
-            lambda: self.lambda_client.invoke(
+        response = self.lambda_client.invoke(
                 FunctionName=self.lambda_function_name,
-                InvocationType='RequestResponse',
+                InvocationType='Event',
                 Payload=json.dumps(lambda_payload)
-            )
         )
         logger.info(f"Lambda invocation response: {response}")
 
-        # Check for errors
-        if response['StatusCode'] != 200:
-            error_msg = f"Lambda invocation failed with status {response['StatusCode']}"
-            logger.error(f"{error_msg}: {response}")
-            run.system_logs.append(error_msg)
-            attributes.flag_modified(run, "system_logs")
-            await db.commit()
-            return {}
-
-        # Parse response
-        # The payload is the result of the lambda fn calling Omics.
-        response_payload = json.loads(response['Payload'].read())
-        logger.info(f"Lambda invocation response payload: {response_payload}")
-
-        if response_payload.get('statusCode') != 200:
-            error_msg = (f"Workflow submission failed: "
-                         f"{response_payload.get('message', 'Unknown error')}")
-            logger.error(error_msg)
-            run.system_logs.append(error_msg)
-            attributes.flag_modified(run, "system_logs")
-            await db.commit()
-            return {}
-
-        return response_payload
 
     async def _get_engine_id_from_ngs360(self, workflow_url: str) -> str:
         """
@@ -149,89 +115,198 @@ class LambdaWorkflowSubmissionService(WorkflowSubmissionService):
             workflow_url: The workflow URL in format NGS360WORKFLOWID[:ALIAS_OR_VERSION]
 
         Returns:
-            The engine_id from the NGS360 API
+            The workflow id on the requested engine from the NGS360 API
 
         Raises:
-            RuntimeError: If API call fails or engine_id not found
+            RuntimeError: If API call fails or workflow_engine_id not found
         """
-        if ':' in workflow_url:
-            if len(workflow_url.split(':')) > 2:
-                raise RuntimeError(
-                    "Workflow URL format error - expect NGS360WORKFLOWID[:ALIAS_OR_VERSION"
-                )
-            else:
-                workflow_id = workflow_url.split(':')[0]
-                suffix = workflow_url.split(':')[1]
-        else:
-            workflow_id = workflow_url
-            suffix = None
+        workflow_id, suffix = self._parse_workflow_url(workflow_url)
+        workflow_data = await self._fetch_workflow_from_api(workflow_id)
+        selected_version = self._select_version(workflow_data, suffix, workflow_id)
+        workflow_engine_id = self._select_deployment(selected_version, suffix, workflow_id)
 
-        # Construct the API URL
+        logger.info(
+            f"Successfully retrieved workflow_engine_id '{workflow_engine_id}' for workflow {workflow_url}"
+        )
+        return workflow_engine_id
+
+    def _parse_workflow_url(self, workflow_url: str) -> tuple[str, str | None]:
+        """
+        Parse workflow URL into ID and optional suffix (alias/version).
+
+        Args:
+            workflow_url: The workflow URL in format NGS360WORKFLOWID[:ALIAS_OR_VERSION]
+
+        Returns:
+            Tuple of (workflow_id, suffix) where suffix may be None
+
+        Raises:
+            RuntimeError: If URL format is invalid
+        """
+        if ':' not in workflow_url:
+            return workflow_url, None
+
+        parts = workflow_url.split(':')
+        if len(parts) > 2:
+            raise RuntimeError(
+                "Workflow URL format error - expect NGS360WORKFLOWID[:ALIAS_OR_VERSION]"
+            )
+        return parts[0], parts[1]
+
+    async def _fetch_workflow_from_api(self, workflow_id: str) -> dict:
+        """
+        Fetch workflow data from NGS360 API.
+
+        Args:
+            workflow_id: The NGS360 workflow ID
+
+        Returns:
+            Workflow data dictionary from the API
+
+        Raises:
+            RuntimeError: If API call fails
+        """
         api_url = f"{self.ngs360_api_url}/api/v1/workflows/{workflow_id}"
         logger.info(f"Querying NGS360 API for workflow {workflow_id}: {api_url}")
 
         async with httpx.AsyncClient() as client:
             response = await client.get(api_url)
+
         if response.status_code != 200:
             raise RuntimeError(
                 f"NGS360 API returned status {response.status_code}: {response.text}"
             )
-        workflow_data = response.json()
+        return response.json()
 
-        alias = workflow_data.get("aliases", [])
+    def _find_version_by_alias(
+        self,
+        aliases: list[dict],
+        versions: list[dict],
+        alias_name: str,
+    ) -> dict | None:
+        """
+        Find version matching the given alias.
+
+        Args:
+            aliases: List of alias entries from workflow data
+            versions: List of version entries from workflow data
+            alias_name: The alias name to search for
+
+        Returns:
+            Matching version dict, or None if not found
+        """
+        for alias_entry in aliases:
+            if alias_entry["alias"] == alias_name:
+                alias_version = alias_entry["version"]
+                matching = [v for v in versions if v["version"] == alias_version]
+                return matching[0] if matching else None
+        return None
+
+    def _find_version_by_number(
+        self,
+        versions: list[dict],
+        version_str: str,
+    ) -> dict | None:
+        """
+        Find version by direct version number string.
+
+        Args:
+            versions: List of version entries from workflow data
+            version_str: Version number as a string
+
+        Returns:
+            Matching version dict, or None if not found
+        """
+        for version_entry in versions:
+            if str(version_entry["version"]) == version_str:
+                return version_entry
+        return None
+
+    def _select_version(
+        self,
+        workflow_data: dict,
+        suffix: str | None,
+        workflow_id: str,
+    ) -> dict:
+        """
+        Select the appropriate workflow version based on suffix or return latest.
+
+        Args:
+            workflow_data: Full workflow data from the API
+            suffix: Optional alias or version suffix
+            workflow_id: The workflow ID (for error messages)
+
+        Returns:
+            Selected version dictionary
+
+        Raises:
+            RuntimeError: If no versions exist or specified version not found
+        """
         versions = workflow_data.get("versions", [])
         if not versions:
             raise RuntimeError(
                 f"No versions found for workflow {workflow_id} in NGS360 API response"
             )
 
-        if suffix:
-            # Check if match with any alias
-            selected_version = None
-            if alias:
-                for alias_element in alias:
-                    if alias_element["alias"] == suffix:
-                        alias_version = alias_element["version"]
-                        selected_version = [c for c in versions if c["version"] == alias_version][0]
-                        break
+        if not suffix:
+            return max(versions, key=lambda v: v["version"])
 
-            # Get specified version
-            if not selected_version:
-                for version_element in versions:
-                    if str(version_element["version"]) == suffix:
-                        selected_version = version_element
+        # Try alias first, then direct version number
+        aliases = workflow_data.get("aliases", [])
+        selected = self._find_version_by_alias(aliases, versions, suffix)
 
-            if not selected_version:
-                raise RuntimeError(
-                    f"Specified Alias/Version {suffix} is not found for workflow {workflow_id}."
-                )
-        else:
-            # Get latest version when not specified
-            latest_version = versions[0]
-            for version_element in versions:
-                if version_element["version"] > latest_version["version"]:
-                    latest_version = version_element
-            selected_version = latest_version
+        if not selected:
+            selected = self._find_version_by_number(versions, suffix)
 
-        # Get newest deployment
-        deployments = selected_version.get("deployments", [])
-        deployments = [c for c in deployments if c["engine"] == "AWSHealthOmics (us-east)"]
-        if not deployments:
+        if not selected:
             raise RuntimeError(
-                f"Specified Alias/Version {suffix} has no deployments in AWSHealthOmics (us-east)."
+                f"Specified Alias/Version {suffix} is not found for workflow {workflow_id}."
             )
 
-        last_deployment = deployments[0]
-        for deployment in deployments:
-            creatd = datetime.fromisoformat(deployment["created_at"])
-            if creatd > datetime.fromisoformat(last_deployment["created_at"]):
-                last_deployment = deployment
-        engine_id = last_deployment["external_id"]
+        return selected
+
+    def _select_deployment(
+        self,
+        version: dict,
+        suffix: str | None,
+        workflow_id: str,
+    ) -> str:
+        """
+        Select the most recent AWSHealthOmics deployment and return its engine_id.
+
+        Args:
+            version: The selected version dictionary
+            suffix: The alias/version suffix (for error messages)
+            workflow_id: The workflow ID (for error messages)
+
+        Returns:
+            The engine_id string from the selected deployment
+
+        Raises:
+            RuntimeError: If no deployments found or engine_id is empty
+        """
+        deployments = version.get("deployments", [])
+        omics_deployments = [
+            d for d in deployments
+            if d["engine"] == "AWSHealthOmics (us-east)"
+        ]
+
+        if not omics_deployments:
+            raise RuntimeError(
+                f"Specified Alias/Version {suffix} has no deployments "
+                f"in AWSHealthOmics (us-east)."
+            )
+
+        latest = max(
+            omics_deployments,
+            key=lambda d: datetime.fromisoformat(d["created_at"]),
+        )
+
+        engine_id = latest["external_id"]
         if not engine_id:
             raise RuntimeError(
                 f"engine_id not found for workflow {workflow_id} deployment "
-                f"{last_deployment['id']} in NGS360 API response"
+                f"{latest['id']} in NGS360 API response"
             )
 
-        logger.info(f"Successfully retrieved engine_id '{engine_id}' for workflow {workflow_url}")
         return engine_id

--- a/src/wes_service/services/workflow_submission_service.py
+++ b/src/wes_service/services/workflow_submission_service.py
@@ -65,7 +65,7 @@ class LambdaWorkflowSubmissionService(WorkflowSubmissionService):
         """
         # Get engine_id from NGS360 API using the workflow_url as the workflow ID
         try:
-            engine_id = await self._get_engine_id_from_ngs360(run_request.workflow_url)
+            workflow_engine_id = await self._get_engine_id_from_ngs360(run_request.workflow_url)
         except RuntimeError as e:
             error_msg = (
                 f"Failed to retrieve engine_id from NGS360 API for workflow "
@@ -74,12 +74,12 @@ class LambdaWorkflowSubmissionService(WorkflowSubmissionService):
             logger.error(error_msg)
             return
 
-        # Prepare Lambda payload using the engine_id instead of workflow_id
+        # Prepare Lambda payload
         lambda_payload = {
             'action': 'submit_workflow',
             'source': 'ga4ghwes',
             'wes_run_id': run_request.id,
-            'workflow_id': engine_id,  # Use engine_id from NGS360 API
+            'workflow_id': workflow_engine_id,
             'workflow_version': (
                 run_request.workflow_params.get('workflow_version')
                 if run_request.workflow_params else None
@@ -105,7 +105,6 @@ class LambdaWorkflowSubmissionService(WorkflowSubmissionService):
                 Payload=json.dumps(lambda_payload)
         )
         logger.info(f"Lambda invocation response: {response}")
-
 
     async def _get_engine_id_from_ngs360(self, workflow_url: str) -> str:
         """

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -16,12 +16,8 @@ WORKFLOW_SUBMIT_PATCH = (
 class TestPAMLFunctions:
     """Tests endpoint as PAML would do.."""
 
-    @patch(WORKFLOW_SUBMIT_PATCH)
-    async def test_paml_submit_task(self, mock_submit, client: TestClient):
+    def test_paml_submit_task(self, client: TestClient):
         """Test submit task through PAML"""
-        # Mock the workflow submission to return a successful response
-        mock_submit.return_value = {"omics_run_id": "123456"}
-
         # Mimic inputs of PAML submit_task()
         name = "test_wes_run"
         project = {

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -2,7 +2,6 @@
 
 import io
 import json
-from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 from src.wes_service.db.models import WorkflowRun, WorkflowState

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -16,48 +16,6 @@ WORKFLOW_SUBMIT_PATCH = (
 class TestPAMLFunctions:
     """Tests endpoint as PAML would do.."""
 
-    def test_paml_submit_task(self, client: TestClient):
-        """Test submit task through PAML"""
-        # Mimic inputs of PAML submit_task()
-        name = "test_wes_run"
-        project = {
-            "name": "test_project_name",
-            "id": "test_project_id",
-        }
-        workflow = "1234567"
-        parameters = {
-            "input_file": "s3://bucket/input.fastq",
-            "reference_genome": "s3://bucket/reference.fa"
-        }
-        execution_settings = {"cacheId": "12345"}
-
-        # Mock run
-        workflow_engine_parameters = {
-            "cacheId": execution_settings["cacheId"],
-            "name": name
-        }
-        tags = {
-            "TaskName": name,
-            "ProjectId": project["id"],
-        }
-        response = client.post(
-            "/ga4gh/wes/v1/runs",
-            data={
-                "workflow_url": workflow,
-                "workflow_type": "CWL",
-                "workflow_type_version": "v1.0",
-                "workflow_params": json.dumps(parameters),
-                "workflow_engine_parameters": json.dumps(workflow_engine_parameters),
-                "tags": json.dumps(tags),
-            },
-        )
-
-        # Verify run was created correctly and added to db
-        assert response.status_code == 200
-        data = response.json()
-        assert "run_id" in data
-        assert isinstance(data["run_id"], str)
-
     async def test_paml_get_task_state(self, client: TestClient, test_db):
         """Test get task state through PAML"""
         # Mimic inputs of PAML get_task_state()

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -252,12 +252,8 @@ class TestPAMLFunctions:
 class TestSubmitWorkflow:
     """Tests for POST /runs endpoint."""
 
-    @patch(WORKFLOW_SUBMIT_PATCH)
-    def test_submit_workflow_minimal(self, mock_submit, client: TestClient):
+    def test_submit_workflow_minimal(self, client: TestClient):
         """Test submitting a workflow with minimal parameters."""
-        # Mock the workflow submission to return a successful response
-        mock_submit.return_value = {"omics_run_id": "123456"}
-
         response = client.post(
             "/ga4gh/wes/v1/runs",
             data={
@@ -272,12 +268,8 @@ class TestSubmitWorkflow:
         assert "run_id" in data
         assert isinstance(data["run_id"], str)
 
-    @patch(WORKFLOW_SUBMIT_PATCH)
-    def test_submit_workflow_with_params(self, mock_submit, client: TestClient):
+    def test_submit_workflow_with_params(self, client: TestClient):
         """Test submitting a workflow with parameters."""
-        # Mock the workflow submission to return a successful response
-        mock_submit.return_value = {"omics_run_id": "123456"}
-
         params = {"input_file": "s3://bucket/input.txt"}
 
         response = client.post(
@@ -297,12 +289,8 @@ class TestSubmitWorkflow:
         data = response.json()
         assert "run_id" in data
 
-    @patch(WORKFLOW_SUBMIT_PATCH)
-    def test_submit_workflow_with_attachments(self, mock_submit, client: TestClient):
+    def test_submit_workflow_with_attachments(self, client: TestClient):
         """Test submitting a workflow with file attachments."""
-        # Mock the workflow submission to return a successful response
-        mock_submit.return_value = {"omics_run_id": "123456"}
-
         files = [
             ("workflow_attachment", ("workflow.cwl", io.BytesIO(b"content1"))),
             ("workflow_attachment", ("inputs.json", io.BytesIO(b"content2"))),

--- a/tests/services/test_run_service.py
+++ b/tests/services/test_run_service.py
@@ -67,7 +67,7 @@ class TestRunService:
         """Test creating a new workflow run."""
         service = RunService(test_db, mock_storage)
 
-        result_dict = await service.create_run(
+        workflow_run = await service.create_run(
             workflow_params='{"input": "value"}',
             workflow_type="CWL",
             workflow_type_version="v1.0",
@@ -80,9 +80,8 @@ class TestRunService:
             user_id="testuser",
         )
 
-        assert result_dict is not None
-        assert "run_id" in result_dict
-        run_id = result_dict["run_id"]
+        assert workflow_run is not None
+        run_id = workflow_run.id
         assert isinstance(run_id, str)
 
         # Verify run was created in database

--- a/tests/services/test_run_service.py
+++ b/tests/services/test_run_service.py
@@ -1,7 +1,6 @@
 """Tests for run service."""
 
 import pytest
-import json
 
 from src.wes_service.db.models import WorkflowRun, WorkflowState
 from src.wes_service.services.run_service import RunService

--- a/tests/services/test_run_service.py
+++ b/tests/services/test_run_service.py
@@ -31,54 +31,6 @@ def mock_workflow_submission():
 @pytest.mark.asyncio
 class TestRunService:
     """Tests for RunService."""
-
-    async def test_paml_submit_task(self, test_db, mock_storage):
-        """Test submit task through PAML"""
-        # Mimic inputs of PAML submit_task()
-        name = "test_wes_run"
-        project = {
-            "name": "test_project_name",
-            "id": "test_project_id",
-        }
-        workflow = "1234567"
-        parameters = {
-            "input_file": "s3://bucket/input.fastq",
-            "reference_genome": "s3://bucket/reference.fa"
-        }
-        execution_settings = {"cacheId": "12345"}
-
-        # Mock run service - we need to pass the workflow_submission mock
-        service = RunService(test_db, mock_storage)
-
-        workflow_engine_parameters = {
-            "cacheId": execution_settings["cacheId"],
-            "name": name
-        }
-        result_dict = await service.create_run(
-            workflow_params=json.dumps(parameters),
-            workflow_type="CWL",
-            workflow_type_version="v1.0",
-            workflow_url=workflow,
-            tags=json.dumps({"TaskName": name, "ProjectId": project["id"]}),
-            workflow_engine_parameters=json.dumps(
-                workflow_engine_parameters
-            ),
-            workflow_attachments=None,
-            workflow_engine="CWL",
-            workflow_engine_version="v1.0",
-            user_id="ngs360",
-        )
-
-        # Verify run was created correctly and added to db
-        assert result_dict is not None
-        assert "run_id" in result_dict
-        run_id = result_dict["run_id"]
-        assert isinstance(run_id, str)
-        result = await test_db.get(WorkflowRun, run_id)
-        assert result is not None
-        assert result.workflow_type == "CWL"
-        assert result.state == WorkflowState.QUEUED
-
     async def test_paml_get_task_state(self, test_db, mock_storage):
         """Test get task state through PAML"""
         # Mimic inputs of PAML get_task_state()

--- a/tests/services/test_run_service.py
+++ b/tests/services/test_run_service.py
@@ -32,7 +32,7 @@ def mock_workflow_submission():
 class TestRunService:
     """Tests for RunService."""
 
-    async def test_paml_submit_task(self, test_db, mock_storage, mock_workflow_submission):
+    async def test_paml_submit_task(self, test_db, mock_storage):
         """Test submit task through PAML"""
         # Mimic inputs of PAML submit_task()
         name = "test_wes_run"
@@ -48,7 +48,7 @@ class TestRunService:
         execution_settings = {"cacheId": "12345"}
 
         # Mock run service - we need to pass the workflow_submission mock
-        service = RunService(test_db, mock_storage, mock_workflow_submission)
+        service = RunService(test_db, mock_storage)
 
         workflow_engine_parameters = {
             "cacheId": execution_settings["cacheId"],
@@ -79,7 +79,7 @@ class TestRunService:
         assert result.workflow_type == "CWL"
         assert result.state == WorkflowState.QUEUED
 
-    async def test_paml_get_task_state(self, test_db, mock_storage, mock_workflow_submission):
+    async def test_paml_get_task_state(self, test_db, mock_storage):
         """Test get task state through PAML"""
         # Mimic inputs of PAML get_task_state()
         task = {
@@ -103,7 +103,7 @@ class TestRunService:
         test_db.add(run)
         await test_db.commit()
 
-        service = RunService(test_db, mock_storage, mock_workflow_submission)
+        service = RunService(test_db, mock_storage)
 
         # Get task status
         status = await service.get_run_status(task["id"], None)
@@ -111,9 +111,9 @@ class TestRunService:
         assert status.run_id == "test-get-state"
         assert status.state.value == "COMPLETE"
 
-    async def test_create_run(self, test_db, mock_storage, mock_workflow_submission):
+    async def test_create_run(self, test_db, mock_storage):
         """Test creating a new workflow run."""
-        service = RunService(test_db, mock_storage, mock_workflow_submission)
+        service = RunService(test_db, mock_storage)
 
         result_dict = await service.create_run(
             workflow_params='{"input": "value"}',
@@ -139,9 +139,9 @@ class TestRunService:
         assert result.workflow_type == "CWL"
         assert result.state == WorkflowState.QUEUED
 
-    async def test_list_runs_empty(self, test_db, mock_storage, mock_workflow_submission):
+    async def test_list_runs_empty(self, test_db, mock_storage):
         """Test listing runs when none exist."""
-        service = RunService(test_db, mock_storage, mock_workflow_submission)
+        service = RunService(test_db, mock_storage)
 
         result = await service.list_runs(
             page_size=10,
@@ -152,7 +152,7 @@ class TestRunService:
         assert result.runs == []
         assert result.next_page_token == ""
 
-    async def test_get_run_status(self, test_db, mock_storage, mock_workflow_submission):
+    async def test_get_run_status(self, test_db, mock_storage):
         """Test getting run status."""
         run = WorkflowRun(
             id="test-status",
@@ -167,13 +167,13 @@ class TestRunService:
         test_db.add(run)
         await test_db.commit()
 
-        service = RunService(test_db, mock_storage, mock_workflow_submission)
+        service = RunService(test_db, mock_storage)
         status = await service.get_run_status("test-status", None)
 
         assert status.run_id == "test-status"
         assert status.state.value == "RUNNING"
 
-    async def test_cancel_run(self, test_db, mock_storage, mock_workflow_submission):
+    async def test_cancel_run(self, test_db, mock_storage):
         """Test canceling a run."""
         run = WorkflowRun(
             id="test-cancel",
@@ -188,7 +188,7 @@ class TestRunService:
         test_db.add(run)
         await test_db.commit()
 
-        service = RunService(test_db, mock_storage, mock_workflow_submission)
+        service = RunService(test_db, mock_storage)
         result = await service.cancel_run("test-cancel", None)
 
         assert result == "test-cancel"
@@ -217,7 +217,7 @@ class TestRunService:
             test_db.add(run)
         await test_db.commit()
 
-        service = RunService(test_db, mock_storage, mock_workflow_submission)
+        service = RunService(test_db, mock_storage)
         counts = await service.get_system_state_counts()
 
         assert isinstance(counts, dict)

--- a/tests/services/test_workflow_submission_service.py
+++ b/tests/services/test_workflow_submission_service.py
@@ -481,7 +481,4 @@ class TestWorkflowSubmissionService:
             mock_db.commit = AsyncMock()
 
             # Test error handling - service catches exception and returns empty dict
-            result = await service.submit_workflow(run, mock_db)
-
-        # Verify that service returns empty dict on NGS360 failure
-        assert result == {}
+            await service.submit_workflow(run, mock_db)

--- a/tests/services/test_workflow_submission_service.py
+++ b/tests/services/test_workflow_submission_service.py
@@ -377,13 +377,8 @@ class TestWorkflowSubmissionService:
         # Mock Lambda client
         mock_lambda_client = MagicMock()
         mock_lambda_response = {
-            'StatusCode': 200,
-            'Payload': MagicMock()
+            'StatusCode': 202,
         }
-        mock_lambda_response['Payload'].read.return_value = json.dumps({
-            'statusCode': 200,
-            'omics_run_id': 'omics-12345'
-        }).encode('utf-8')
         mock_lambda_client.invoke.return_value = mock_lambda_response
         mock_boto3_client.return_value = mock_lambda_client
 
@@ -420,12 +415,11 @@ class TestWorkflowSubmissionService:
             mock_db = MagicMock()
             mock_db.commit = AsyncMock()
 
-            # Test workflow submission
+            # Test workflow submission (Event invocation is fire-and-forget)
             result = await service.submit_workflow(run, mock_db)
 
-        # Verify results
-        assert result['omics_run_id'] == 'omics-12345'
-        assert result['statusCode'] == 200
+        # Event invocation is fire-and-forget, so submit_workflow returns None
+        assert result is None
 
         # Verify Lambda was called with correct payload
         mock_lambda_client.invoke.assert_called_once()


### PR DESCRIPTION
Refactor RunService to not require LambdaWorkflowSubmissionService

Prior to this PR, there was a dependency on the lambda function (via RequestResponse) to AWS Omics, which defeated the purpose of separating the components.  

The PR changes the GA4GH implementation to save the workflow run request and ping the lambda service as an event instead.